### PR TITLE
fix: prevent subsequent prereleases after major from affecting minor

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -4,9 +4,17 @@ function isPrerelease(version) {
   return version.includes('-');
 }
 
+function isPreMajor(version) {
+  return semver.minor(version) === 0 && semver.patch(version) === 0 && semver.prerelease(version);
+}
+
 function getNewVersion(lastTag, conventionalReleaseType, prerelease) {
   if (!lastTag) {
     return prerelease ? '1.0.0-0' : '1.0.0';
+  }
+
+  if (isPreMajor(lastTag) && prerelease) {
+    return semver.inc(lastTag, 'prerelease', prerelease);
   }
 
   const releaseType = getReleaseType(lastTag, conventionalReleaseType, prerelease);

--- a/utils.test.js
+++ b/utils.test.js
@@ -30,6 +30,7 @@ describe('getNewVersion', () => {
     [null, 'minor', false, '1.0.0'],
     [null, 'major', false, '1.0.0'],
     [null, 'major', true, '1.0.0-0'],
+    ['2.0.0-0', 'minor', true, '2.0.0-1'],
   ];
 
   test.each(cases)('%s with %s and prerelease: %j should be %s', (lastTag, bumpType, prerelease, expectation) => {


### PR DESCRIPTION
Prior to this fix, if I'm currently at `2.0.0-0` and send a minor bump, it would return to `2.1.0-0`. After this fix, it appropriately returns to `2.0.0-1`. Any sort of prerelease bump against an existing prerelease should not affect the patch or minor values after a major bump. Otherwise we get a release history like this (in ascending chronological order):

1.0.0
1.0.1
2.0.0-0
2.1.0-0
2.1.1-0
2.1.1

Prod releases should not jump from 1.0.1 to 2.1.1. It should really go like this:

1.0.0
1.0.1
2.0.0-0
2.0.0-1
2.0.0-2
2.0.0