### PR TITLE
fix: not all first releases should be a prod release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,9 +79,12 @@ async function run() {
     core.info(`conventional release type ${recommendation.releaseType}`);
 
     const prerelease = core.getBooleanInput('prerelease');
-    const newVersion = latestRelease
-      ? getNewVersion(latestRelease, recommendation.releaseType as string, prerelease, latestProdRelease as string)
-      : '1.0.0';
+    const newVersion = getNewVersion(
+      latestRelease,
+      recommendation.releaseType as string,
+      prerelease,
+      latestProdRelease as string,
+    );
 
     core.info(`prerelease: ${prerelease}`);
     core.info(`next version: ${newVersion}`);


### PR DESCRIPTION
This ternary expression that I'm removing is handled in a better way in the getNewVersion function.

Fixes #166