### PR TITLE
fix: ignore releases with null tags

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -74,4 +74,20 @@ describe('getLatestRelease', () => {
 
     expect(getLatestRelease(edges)).toBe(expectation);
   });
+
+  test('should skip null tags', () => {
+    const edges = [
+      { node: { tag: { name: 'v1.0.0' } } },
+      { node: { tag: null } },
+      { node: { tag: { name: 'v2.0.0' } } },
+    ];
+
+    expect(getLatestRelease(edges)).toBe('v2.0.0');
+  });
+
+  test('can handle all null tags', () => {
+    const edges = [{ node: { tag: null } }, { node: { tag: null } }];
+
+    expect(getLatestRelease(edges)).toBe(null);
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,11 +57,11 @@ function getReleaseType(
 }
 
 export function getLatestRelease(releasesQueryResponse: any[]): string | null {
-  if (releasesQueryResponse.length === 0) {
+  const releases = releasesQueryResponse.filter((release) => release.node.tag).map((release) => release.node.tag.name);
+
+  if (releases.length === 0) {
     return null;
   }
-
-  const releases = releasesQueryResponse.map((release) => release.node.tag.name);
 
   releases.sort((x, y) => (semver.gt(x, y) ? -1 : 1));
 


### PR DESCRIPTION
Prior to this change, the action would crash with the following error: "Cannot read properties of null (reading 'name')"

I wasn't able to find a way to filter the data via the GraphQL query so I just used JS.

Here's an example of some release data with null tags from palletjack:

![image](https://github.com/user-attachments/assets/238b12cd-6ef9-4bce-8ed8-220186dfc777)
