### PR TITLE
fix: skip release versions that are not valid semver

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -46,6 +46,7 @@ describe('getNewVersion', () => {
 describe('getLatestRelease', () => {
   const cases: [string[], string | null][] = [
     [[], null],
+    [['invalid', 'v1.2.1'], 'v1.2.1'],
     [
       [
         'v2.1.0',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,9 @@ function getReleaseType(
 }
 
 export function getLatestRelease(releasesQueryResponse: any[]): string | null {
-  const releases = releasesQueryResponse.filter((release) => release.node.tag).map((release) => release.node.tag.name);
+  const releases = releasesQueryResponse
+    .filter((release) => release.node.tag && semver.valid(release.node.tag.name))
+    .map((release) => release.node.tag.name);
 
   if (releases.length === 0) {
     return null;


### PR DESCRIPTION
It was failing on a version named: "3.0.0b6"