### PR TITLE
fix: if no previous prod release, return 1.0.0 if no prerelease

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getLatestRelease, getNewVersion } from './utils.js';
 
 async function run() {
   try {
-    core.startGroup('Finding last tag...');
+    core.info('Finding last tag...');
 
     // get the last tag
     const octokit = github.getOctokit(core.getInput('repo-token'));
@@ -70,15 +70,20 @@ async function run() {
 
     core.setOutput('current-version-number', currentVersion);
 
-    core.info(`latest release ${latestRelease ?? 'first release'}`);
-    core.endGroup();
-
     // pass an object rather than a string to make sure that it gets included in the build
     const bumper = new Bumper(process.cwd()).loadPreset('angular');
     const recommendation = await bumper.bump();
-    core.info(`conventional release type ${recommendation.releaseType}`);
 
     const prerelease = core.getBooleanInput('prerelease');
+
+    // these are helpful in diagnosing issues and adding new test cases
+    core.info(`latest tag: ${latestRelease ?? 'first release'}`);
+    core.info(`conventional release type ${recommendation.releaseType}`);
+    core.info(`prerelease: ${prerelease}`);
+    core.info(`latest prod release: ${latestProdRelease}`);
+
+    core.info(`current-version-number (output): ${currentVersion}`);
+
     const newVersion = getNewVersion(
       latestRelease,
       recommendation.releaseType as string,
@@ -86,8 +91,7 @@ async function run() {
       latestProdRelease as string,
     );
 
-    core.info(`prerelease: ${prerelease}`);
-    core.info(`next version: ${newVersion}`);
+    core.info(`version (output): ${newVersion}`);
 
     core.setOutput('version', newVersion);
     if (newVersion) {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -38,6 +38,7 @@ describe('getNewVersion', () => {
     ['0.1.0-0', 'minor', true, null, '0.1.0-1'],
     ['2.0.0-5', 'minor', false, '1.3.4', '1.4.0'],
     [null, 'patch', false, null, '1.0.0'],
+    ['1.0.0-3', 'patch', false, null, '1.0.0'],
   ];
 
   test.each(cases)('%s, %s, %j, %s => %s', (lastTag, bumpType, prerelease, lastProdTag, expectation) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,10 @@ export function getNewVersion(
     return prerelease ? '1.0.0-0' : '1.0.0';
   }
 
+  if (!prerelease && !lastProdTag) {
+    return '1.0.0';
+  }
+
   /* If the last tag was a major prerelease, we shouldn't
   bump anything but the prerelease number. For example, if the
   last tag was 2.0.0-0 and this is a minor bump, we should
@@ -29,7 +33,7 @@ export function getNewVersion(
 
   const releaseType = getReleaseType(lastTag, conventionalReleaseType, prerelease, lastProdTag);
 
-  return semver.inc(prerelease ? lastTag : lastProdTag ?? '0.0.0', releaseType, prerelease);
+  return semver.inc(prerelease ? lastTag : lastProdTag ?? '1.0.0', releaseType, prerelease);
 }
 
 function getReleaseType(


### PR DESCRIPTION
Here's an example of what this fixes: https://github.com/agrc/plpco-rdcc-notifications/pull/147